### PR TITLE
Speed up geohashing for level 9&up; update test_zero.py

### DIFF
--- a/geoh/geoh.py
+++ b/geoh/geoh.py
@@ -13,7 +13,12 @@ def geohashes(geojson={}, precision=6, start_precision=2):
     if not polygon:
         return []
 
+    precision_init = precision
+    if precision_init >= 9:
+        precision = precision - 1
+
     p = min(start_precision, precision)
+
     center_geohash = get_center_geohash(polygon, precision=p)
     _geohashes = [center_geohash] + gh.neighbors(center_geohash)
     _geohashes = geohashes_polygon_intersection(polygon, _geohashes)
@@ -23,7 +28,18 @@ def geohashes(geojson={}, precision=6, start_precision=2):
         _geohashes = geohashes_polygon_intersection(polygon, _geohashes)
         p += 1
 
-    return _geohashes
+    if precision_init >= 9:
+        inside_geohashes_coarse =  geohashes_polygon_within(polygon, _geohashes)
+        inside_geohashes = _generate_inner_geohashes_for_geohashes(inside_geohashes_coarse)
+
+        intersect_geohashes_coarse = list(set(_geohashes) - set(inside_geohashes_coarse))
+        intersect_geohashes = _generate_inner_geohashes_for_geohashes(intersect_geohashes_coarse)
+        intersect_geohashes = geohashes_polygon_intersection(polygon, intersect_geohashes)
+
+        return inside_geohashes + intersect_geohashes
+
+    else:
+        return _geohashes
 
 def get_center_geohash(polygon, precision=2):
     centroid = mapping(polygon.centroid)["coordinates"]
@@ -33,8 +49,14 @@ def geohashes_polygon_intersection(polygon, geohashes=[]):
     """Return geohashes that intersect `polygon`"""
     from itertools import compress
     geoms = map(_geohash_to_shape, geohashes)
-    intersections = map(lambda gh: gh.intersects(polygon), geoms)
+    intersections = map(lambda g_h: g_h.intersects(polygon), geoms)
     return list(compress(geohashes, intersections))
+
+def geohashes_polygon_within(polygon, geohashes=[]):
+    from itertools import compress
+    geoms = map(_geohash_to_shape, geohashes)
+    withins = map(lambda g_h: g_h.within(polygon), geoms)
+    return list(compress(geohashes, withins))
 
 def _generate_inner_geohashes_for_geohashes(geohashes=[]):
     return _flatten(map(_generate_inner_geohashes_for_geohash, geohashes))

--- a/geoh/geoh.py
+++ b/geoh/geoh.py
@@ -15,7 +15,7 @@ def geohashes(geojson={}, precision=6, start_precision=2):
 
     precision_init = precision
     if precision_init >= 9:
-        precision = precision - 1
+        precision -= 1
 
     p = min(start_precision, precision)
 
@@ -28,18 +28,18 @@ def geohashes(geojson={}, precision=6, start_precision=2):
         _geohashes = geohashes_polygon_intersection(polygon, _geohashes)
         p += 1
 
-    if precision_init >= 9:
-        inside_geohashes_coarse =  geohashes_polygon_within(polygon, _geohashes)
-        inside_geohashes = _generate_inner_geohashes_for_geohashes(inside_geohashes_coarse)
-
-        intersect_geohashes_coarse = list(set(_geohashes) - set(inside_geohashes_coarse))
-        intersect_geohashes = _generate_inner_geohashes_for_geohashes(intersect_geohashes_coarse)
-        intersect_geohashes = geohashes_polygon_intersection(polygon, intersect_geohashes)
-
-        return inside_geohashes + intersect_geohashes
-
-    else:
+    if precision_init < 9:
         return _geohashes
+
+    inside_geohashes_coarse =  geohashes_polygon_within(polygon, _geohashes)
+    inside_geohashes = _generate_inner_geohashes_for_geohashes(inside_geohashes_coarse)
+
+    intersect_geohashes_coarse = list(set(_geohashes) - set(inside_geohashes_coarse))
+    intersect_geohashes = _generate_inner_geohashes_for_geohashes(intersect_geohashes_coarse)
+    intersect_geohashes = geohashes_polygon_intersection(polygon, intersect_geohashes)
+
+    return inside_geohashes + intersect_geohashes
+
 
 def get_center_geohash(polygon, precision=2):
     centroid = mapping(polygon.centroid)["coordinates"]
@@ -53,6 +53,7 @@ def geohashes_polygon_intersection(polygon, geohashes=[]):
     return list(compress(geohashes, intersections))
 
 def geohashes_polygon_within(polygon, geohashes=[]):
+    """Return geohashes that are within the polygon"""
     from itertools import compress
     geoms = map(_geohash_to_shape, geohashes)
     withins = map(lambda g_h: g_h.within(polygon), geoms)

--- a/test/test_zero.py
+++ b/test/test_zero.py
@@ -28,10 +28,28 @@ def malformed_geojson():
         }]
     }
 
+@pytest.fixture
+def geojson_small():
+    return {
+      "type": "Feature",
+      "geometry": {"coordinates": [[[-80.20607, 40.248738],
+                                    [-80.205726, 40.248738],
+                                    [-80.205726, 40.248484],
+                                    [-80.20607, 40.248484],
+                                    [-80.20607, 40.248738]]],
+                   "type": "Polygon"},
+      "properties": {}
+    }
+
 @pytest.mark.parametrize("precision", [1, 2 ,3, 4, 5, 6])
 def test_sf(geojson_sf, precision):
   geohashes = geoh.geohashes(geojson=geojson_sf, precision=precision)
+  geohashes_5 = geoh.geohashes(geojson=geojson_sf, precision=5)
   assert(len(geohashes) > 0)
+  assert(set(geohashes_5) == set(["9q8yh", "9q8yj", "9q8yk", "9q8ym", "9q8yq",
+                             "9q8ys", "9q8yt", "9q8yu", "9q8yv", "9q8yw",
+                             "9q8yx", "9q8yy", "9q8yz", "9q8zh", "9q8zj",
+                             "9q8zn", "9q8zp"]))
 
 @pytest.mark.parametrize("precision", [1, 2, 3, 4, 5, 6])
 def test_with_none_geojson(geojson_none, precision):
@@ -43,3 +61,20 @@ def test_with_none_geojson(geojson_none, precision):
 def test_with_malformed_geojson(malformed_geojson, precision):
   geohashes = geoh.geohashes(geojson=malformed_geojson, precision=precision)
   assert(geohashes == [])
+
+
+def test_geojson_small_geohash_9(geojson_small, precision=9):
+  geohashes = geoh.geohashes(geojson=geojson_small, precision=precision)
+  assert (set(geohashes) == set(['dpnuyz58r', 'dpnuyz58x', 'dpnuyz58z', 'dpnuyz59p', 'dpnuyz59r',
+                                 'dpnuyz59x', 'dpnuyz59z', 'dpnuyz5b2', 'dpnuyz5b3', 'dpnuyz5b6',
+                                 'dpnuyz5b7', 'dpnuyz5b8', 'dpnuyz5b9', 'dpnuyz5bb', 'dpnuyz5bc',
+                                 'dpnuyz5bd', 'dpnuyz5be', 'dpnuyz5bf', 'dpnuyz5bg', 'dpnuyz5bk',
+                                 'dpnuyz5bm', 'dpnuyz5bq', 'dpnuyz5br', 'dpnuyz5bs', 'dpnuyz5bt',
+                                 'dpnuyz5bu', 'dpnuyz5bv', 'dpnuyz5bw', 'dpnuyz5bx', 'dpnuyz5by',
+                                 'dpnuyz5bz', 'dpnuyz5c0', 'dpnuyz5c1', 'dpnuyz5c2', 'dpnuyz5c3',
+                                 'dpnuyz5c4', 'dpnuyz5c5', 'dpnuyz5c6', 'dpnuyz5c7', 'dpnuyz5c8',
+                                 'dpnuyz5c9', 'dpnuyz5cb', 'dpnuyz5cc', 'dpnuyz5cd', 'dpnuyz5ce',
+                                 'dpnuyz5cf', 'dpnuyz5cg', 'dpnuyz5ch', 'dpnuyz5cj', 'dpnuyz5ck',
+                                 'dpnuyz5cm', 'dpnuyz5cn', 'dpnuyz5cp', 'dpnuyz5cq', 'dpnuyz5cr',
+                                 'dpnuyz5cs', 'dpnuyz5ct', 'dpnuyz5cu', 'dpnuyz5cv', 'dpnuyz5cw',
+                                 'dpnuyz5cx', 'dpnuyz5cy', 'dpnuyz5cz']))


### PR DESCRIPTION
Given a desired precision, current geohashes function in geoh library:

1. Gathers geohashes that are one level lower resolution and intersect the polygon.
2. Get all their child geohashes and check their intersection with the polygon.

Main change in this pull request is in step 2.
- If the lower resolution geohash is within the polygon, get all the desired precision geohashes inside of this geohash and no need to check their intersections.
- For the lower resolution geohashes that are intersecting the boundary of the polygon, get their child geohashes and check for intersected child geohashes.
Depending on the polygon used, this change reduces the time of geohashing a polygon to level 9 geohash by more than 10%.